### PR TITLE
docs: add missing prerequisites and cross-platform install notes to setup.md

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+{
+  "name": "Everything GitHub Copilot Lab",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "9.0",
+      "installUsingApt": true
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "installDirectlyFromGitHubRelease": true,
+      "version": "latest"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp"
+      ],
+      "settings": {
+        "dotnet.defaultSolution": "ContosoUniversity.sln"
+      }
+    }
+  },
+
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+
+  "remoteEnv": {
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+    "DOTNET_NOLOGO": "1"
+  },
+
+  "forwardPorts": [52379, 52380],
+  "portsAttributes": {
+    "52379": { "label": "ContosoUniversity (HTTPS)", "onAutoForward": "notify" },
+    "52380": { "label": "ContosoUniversity (HTTP)", "onAutoForward": "notify" }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Installing lab prerequisites ==="
+
+# Copilot CLI
+echo "Installing GitHub Copilot CLI..."
+npm install -g @github/copilot
+
+# GitHub Agentic Workflows extension
+echo "Installing gh-aw extension..."
+gh extension install github/gh-aw || true
+
+# jq (used by hook scripts)
+echo "Installing jq..."
+sudo apt-get update -qq && sudo apt-get install -y -qq jq > /dev/null
+
+# Restore .NET packages
+echo "Restoring .NET packages..."
+dotnet restore ContosoUniversity.sln
+
+# Build the solution to verify everything works
+echo "Building solution..."
+dotnet build ContosoUniversity.sln --no-restore
+
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "Verify your tools:"
+echo "  dotnet --version          → .NET SDK"
+echo "  node --version            → Node.js"
+echo "  gh --version              → GitHub CLI"
+echo "  copilot --version         → Copilot CLI"
+echo "  gh aw version             → Agentic Workflows"
+echo "  jq --version              → JSON processor"
+echo ""
+echo "Next steps:"
+echo "  1. Run 'copilot login' to authenticate the Copilot CLI"
+echo "  2. Run 'gh auth login' to authenticate the GitHub CLI"
+echo "  3. Open labs/setup.md and continue from S.2"

--- a/labs/setup.md
+++ b/labs/setup.md
@@ -14,7 +14,26 @@ References:
 - [GitHub CLI](https://cli.github.com/)
 - [GitHub Agentic Workflows](https://github.com/github/gh-aw)
 
-## Prerequisites
+## Quick Start: Dev Container (Recommended)
+
+The fastest way to get a fully working environment is to use the included **Dev Container**, which pre-installs all tools and dependencies automatically.
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) VS Code extension
+2. Fork and clone this repository (see [S.1](#s1-fork-and-clone-the-repository))
+3. Open the repo folder in VS Code
+4. When prompted _"Reopen in Container"_, click **Yes** — or run **Dev Containers: Reopen in Container** from the Command Palette (`Ctrl+Shift+P`)
+5. Wait for the container to build (first time takes a few minutes)
+6. Once open, authenticate: `copilot login` and `gh auth login`
+
+The container includes: .NET 8 + 9 SDKs, Node.js, GitHub CLI, Copilot CLI, gh-aw, jq, and all recommended VS Code extensions.
+
+> **Codespaces:** This Dev Container also works with [GitHub Codespaces](https://github.com/features/codespaces) — click **Code → Codespaces → New codespace** on your fork for a fully cloud-hosted environment.
+
+If you prefer to install tools locally, continue with the manual prerequisites below.
+
+---
+
+## Prerequisites (Manual Install)
 
 Before starting the labs, ensure you have:
 


### PR DESCRIPTION
## Summary

Reduces setup friction by adding a Dev Container that pre-installs all prerequisites, and improves the manual install docs for cross-platform users.

## Changes

### Dev Container (new)
- **\.devcontainer/devcontainer.json\** — .NET 8 + 9 SDKs, Node.js LTS, GitHub CLI, VS Code extensions (Copilot, C# Dev Kit), port forwarding for the web app
- **\.devcontainer/post-create.sh\** — Automatically installs Copilot CLI, gh-aw extension, jq, restores NuGet packages, and builds the solution
- Works with both local Dev Containers and GitHub Codespaces

### setup.md improvements
- **Quick Start: Dev Container** section added as the recommended setup path
- **Node.js** added as explicit prerequisite (was a hidden dependency for \
pm install\ and \
px\)
- **Verification commands** added for every prerequisite
- **Platform-specific install notes** for Linux, macOS, and Windows (collapsible sections)
- Prerequisites reordered logically (Git before GitHub CLI)
- Reference links updated

## What's in the Dev Container

| Tool | Version | Purpose |
|------|---------|---------|
| .NET SDK | 8.0 + 9.0 | Build app (net8.0) + Playwright tests (net9.0) |
| Node.js | LTS | Copilot CLI, MCP servers (npx) |
| GitHub CLI | Latest | \gh\ commands, \gh aw\ |
| Copilot CLI | Latest | \copilot\ commands |
| gh-aw | Latest | Agentic Workflows |
| jq | Latest | Hook scripts |
| VS Code Extensions | — | GitHub Copilot, Copilot Chat, C# Dev Kit |

## Why
Users were hitting \
pm: command not found\ because Node.js wasn't listed. Linux/macOS users had no install guidance. The devcontainer eliminates all of this — one click to a fully working environment.