### PR TITLE
Setup config

### DIFF
--- a/labs/lab01.md
+++ b/labs/lab01.md
@@ -57,7 +57,7 @@ Once installed, plugins are available in your Copilot conversations. Invoke them
 copilot
 
 # Then in the conversation, reference the plugin:
-> @plugin-name help me with my task
+> /plugin-name help me with my task
 ```
 
 > 💡 **Key insight:** Marketplace plugins give you a head start for common workflows — but they're just the beginning. In Lab 03, you'll learn to **create your own agents** tailored to your team's specific needs. Think of marketplace plugins as patterns you can study and customize.


### PR DESCRIPTION
This pull request updates the documentation in `labs/lab01.md` to clarify how to invoke plugins in Copilot conversations. The change updates the example syntax to use a forward slash instead of an at symbol.

- Documentation update:
  * Changed the plugin invocation example from `@plugin-name` to `/plugin-name` to reflect the correct syntax in Copilot conversations.